### PR TITLE
Fix type for "version" in ReleaseModel

### DIFF
--- a/Contentstack.Management.Core/Models/ReleaseModel.cs
+++ b/Contentstack.Management.Core/Models/ReleaseModel.cs
@@ -43,7 +43,7 @@ namespace Contentstack.Management.Core.Models
         public string Uid { get; set; }
 
         [JsonProperty(propertyName: "version")]
-        public string Version { get; set; }
+        public int Version { get; set; }
 
         [JsonProperty(propertyName: "locale")]
         public string Locale { get; set; }


### PR DESCRIPTION
…the `Version` property in the `ReleaseModel` class. This property, which was previously a string, is now an integer.

Changes:
1. The `Version` property in the `ReleaseModel` class, located in the `Contentstack.Management.Core.Models` namespace, has had its data type changed from `string` to `int`. This change will affect how versioning is handled within the application, potentially improving performance and reducing errors related to type conversion.

Reference to the code changes:
- Change in `ReleaseModel` class: The data type of the `Version` property has been changed from `string` to `int`.