### PR TITLE
feat: :sparkles: Adds Early Access Header Support

### DIFF
--- a/Contentstack.Management.Core.Unit.Tests/Core/ContentstackClientTest.cs
+++ b/Contentstack.Management.Core.Unit.Tests/Core/ContentstackClientTest.cs
@@ -74,8 +74,11 @@ namespace Contentstack.Management.Core.Unit.Tests.Core
                 Timeout= TimeSpan.FromSeconds(20),
                 RetryOnError= false,
                 ProxyHost= "proxyHost",
-                ProxyPort= 22
+                ProxyPort= 22,
+                EarlyAccess = new string[] { "ea1", "ea2" }
             });
+
+            Console.WriteLine(contentstackClient);
 
             Assert.AreEqual("token", contentstackClient.contentstackOptions.Authtoken);
             Assert.AreEqual("host", contentstackClient.contentstackOptions.Host);
@@ -89,6 +92,8 @@ namespace Contentstack.Management.Core.Unit.Tests.Core
             Assert.IsTrue(contentstackClient.contentstackOptions.DisableLogging);
             Assert.AreEqual(1234, contentstackClient.contentstackOptions.MaxResponseContentBufferSize);
             Assert.AreEqual(20, contentstackClient.contentstackOptions.Timeout.Seconds);
+            CollectionAssert.AreEqual(new string[] {"ea1", "ea2"}, contentstackClient.contentstackOptions.EarlyAccess);
+            Assert.AreEqual("ea1,ea2", contentstackClient.DefaultRequestHeaders[HeadersKey.EarlyAccessHeader]);
         }
 
         [TestMethod]

--- a/Contentstack.Management.Core/ContentstackClient.cs
+++ b/Contentstack.Management.Core/ContentstackClient.cs
@@ -96,7 +96,7 @@ namespace Contentstack.Management.Core
         /// </code></pre>
         /// </example>
         public ContentstackClient(
-        string authtoken = null,
+            string authtoken = null,
             string host = "api.contentstack.io",
             int port = 443,
             string version = "v3",
@@ -148,6 +148,10 @@ namespace Contentstack.Management.Core
                 _httpClient.Timeout = contentstackOptions.Timeout;
                 _httpClient.MaxResponseContentBufferSize = contentstackOptions.MaxResponseContentBufferSize;
                 LogManager = contentstackOptions.DisableLogging ? LogManager.EmptyLogger : LogManager.GetLogManager(GetType());
+
+                if (contentstackOptions.EarlyAccess != null) {
+                    _httpClient.DefaultRequestHeaders.Add(HeadersKey.EarlyAccessHeader, string.Join(",", contentstackOptions.EarlyAccess));
+                }
             }
 
             SerializerSettings.DateParseHandling = DateParseHandling.None;

--- a/Contentstack.Management.Core/ContentstackClientOptions.cs
+++ b/Contentstack.Management.Core/ContentstackClientOptions.cs
@@ -23,6 +23,11 @@ namespace Contentstack.Management.Core
         /// </summary>
         public string Host { get; set; } = "api.contentstack.io";
 
+        /// <summary>
+        /// The EarlyAccess used to set early access headers for the Contentstack Management API.
+        /// </summary>
+        public string[] EarlyAccess { get; set; }
+
 
         /// <summary>
         /// The Host used to set host url for the Contentstack Management API.

--- a/Contentstack.Management.Core/Utils/HeadersKey.cs
+++ b/Contentstack.Management.Core/Utils/HeadersKey.cs
@@ -6,6 +6,7 @@ namespace Contentstack.Management.Core.Utils
         public const string UserAgentHeader = "User-Agent";
         public const string XUserAgentHeader = "X-User-Agent";
         public const string ContentTypeHeader = "Content-Type";
+        public const string EarlyAccessHeader = "x-header-ea";
 
     }
 }

--- a/Contentstack.Management.Core/contentstack.management.core.csproj
+++ b/Contentstack.Management.Core/contentstack.management.core.csproj
@@ -61,7 +61,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="7.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Adds Early Access Header Support
- Adds a new HeadersKey
- Adds new ContentstackClientOptions
- If String array is passed in EarlyAccess prop, it converts to comma seperated string and adds to default headers of client
- Added Unit test