### PR TITLE
fix: support ScheduledAt in PublishUnpublishDetails

### DIFF
--- a/Contentstack.Management.Core/Services/Models/PublishUnpublishService.cs
+++ b/Contentstack.Management.Core/Services/Models/PublishUnpublishService.cs
@@ -83,7 +83,7 @@ namespace Contentstack.Management.Core.Services.Models
                     writer.WriteValue(locale);
 
                 }
-                if (!string.IsNullOrEmpty(details.Version))
+                if (!string.IsNullOrEmpty(details.ScheduledAt))
                 {
                     writer.WritePropertyName("scheduled_at");
                     writer.WriteValue(details.ScheduledAt);


### PR DESCRIPTION
Replaced `details.Version` with `details.ScheduledAt` to allow scheduling entry publishing.
Without this, `scheduled_at` was not sent to the API.