### PR TITLE
Allow Microsoft Extensions Options 6 and Above

### DIFF
--- a/Contentstack.Management.Core/contentstack.management.core.csproj
+++ b/Contentstack.Management.Core/contentstack.management.core.csproj
@@ -64,7 +64,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="9.0.2" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="[6.0.0,)" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This pull request updates the `Microsoft.Extensions.Options` package dependency in the `Contentstack.Management.Core` project to allow for greater compatibility with different versions.

Dependency management:

* Changed the `Microsoft.Extensions.Options` package reference in `contentstack.management.core.csproj` from a fixed version (`9.0.2`) to a floating version range (`[6.0.0,)`), allowing any version greater than or equal to 6.0.0.