### PR TITLE
feat: migrate Entry, Entry Variant and Variant Group modules to System.Text.Json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [v1.0.0-beta.6](https://github.com/contentstack/contentstack-management-dotnet/tree/v1.0.0-beta.6)
+ - **Entry, Entry Variant & Variant Group STJ Migration Complete**
+   - Migrated Entry and EntryVariant modules from Newtonsoft.Json to System.Text.Json
+   - Fully migrated VariantGroup module with VariantContentTypeLinkService using Utf8JsonWriter
+   - Re-enabled Stack.VariantGroup() method for variant group operations
+   - Updated service constructors to use JsonSerializerOptions instead of JsonSerializer
+   - Enhanced variant group API integration with proper content type linking
+   - Removed build exclusions for VariantGroup files to re-enable module functionality
+
 ## [v1.0.0-beta.5](https://github.com/contentstack/contentstack-management-dotnet/tree/v1.0.0-beta.5)
  - **Environment & Global Field STJ Migration**
    - Migrated Environment and Global Field modules from Newtonsoft.Json to System.Text.Json

--- a/Contentstack.Management.Core/Abstractions/IEntry.cs
+++ b/Contentstack.Management.Core/Abstractions/IEntry.cs
@@ -1,12 +1,11 @@
 using System;
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Contentstack.Management.Core.Abstractions
 {
-    [JsonObject(ItemNullValueHandling = NullValueHandling.Ignore)]
     public interface IEntry
     {
-        [JsonProperty(propertyName: "title")]
+        [JsonPropertyName("title")]
         string Title { get; set; }
     }
 }

--- a/Contentstack.Management.Core/Models/ContentType.cs
+++ b/Contentstack.Management.Core/Models/ContentType.cs
@@ -155,7 +155,6 @@ namespace Contentstack.Management.Core.Models
             return base.DeleteAsync(collection);
         }
 
-        /*
         /// <summary>
         /// <see cref="Models.Entry" /> is the actual piece of content created using one of the defined content types.
         /// </summary>
@@ -177,6 +176,5 @@ namespace Contentstack.Management.Core.Models
             ThrowIfUidEmpty();
             return new Entry(stack, Uid, uid);
         }
-        */
     }
 }

--- a/Contentstack.Management.Core/Models/Entry.cs
+++ b/Contentstack.Management.Core/Models/Entry.cs
@@ -2,11 +2,10 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
+using System.Text.Json;
 using Contentstack.Management.Core.Abstractions;
 using Contentstack.Management.Core.Queryable;
 using Contentstack.Management.Core.Services.Models;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 
 namespace Contentstack.Management.Core.Models
 {
@@ -211,10 +210,10 @@ namespace Contentstack.Management.Core.Models
             stack.ThrowIfNotLoggedIn();
             ThrowIfUidEmpty();
 
-            var service = new DeleteService<Dictionary<string, List<string>>>(stack.client.serializer, stack, resourcePath, "entry", new Dictionary<string, List<string>>()
+            var service = new DeleteService<Dictionary<string, List<string>>>(stack, resourcePath, "entry", new Dictionary<string, List<string>>()
             {
                 {"locales", locales }
-            });
+            }, stjOptions: stack.client.SerializerOptions);
             return stack.client.InvokeSync(service);
         }
 
@@ -235,10 +234,10 @@ namespace Contentstack.Management.Core.Models
             stack.ThrowIfNotLoggedIn();
             ThrowIfUidEmpty();
 
-            var service = new DeleteService<Dictionary<string, List<string>>>(stack.client.serializer, stack, resourcePath, "entry", new Dictionary<string, List<string>>()
+            var service = new DeleteService<Dictionary<string, List<string>>>(stack, resourcePath, "entry", new Dictionary<string, List<string>>()
             {
                 {"locales", locales }
-            });
+            }, stjOptions: stack.client.SerializerOptions);
             return stack.client.InvokeAsync<DeleteService<Dictionary<string, List<string>>>, ContentstackResponse>(service);
         }
 
@@ -264,7 +263,7 @@ namespace Contentstack.Management.Core.Models
 
             collection.Add("locale", locale);
 
-            var service = new LocalizationService<IEntry>(stack.client.serializer, stack, resourcePath, model, "entry", collection);
+            var service = new LocalizationService<IEntry>(stack.client.SerializerOptions, stack, resourcePath, model, "entry", collection);
             return stack.client.InvokeSync(service);
         }
 
@@ -290,7 +289,7 @@ namespace Contentstack.Management.Core.Models
 
             collection.Add("locale", locale);
 
-            var service = new LocalizationService<IEntry>(stack.client.serializer, stack, resourcePath, model, "entry", collection);
+            var service = new LocalizationService<IEntry>(stack.client.SerializerOptions, stack, resourcePath, model, "entry", collection);
             return stack.client.InvokeAsync<LocalizationService<IEntry>, ContentstackResponse>(service);
         }
 
@@ -314,7 +313,7 @@ namespace Contentstack.Management.Core.Models
 
             collection.Add("locale", locale);
 
-            var service = new LocalizationService<IEntry>(stack.client.serializer, stack, resourcePath, null, "entry", collection, true);
+            var service = new LocalizationService<IEntry>(stack.client.SerializerOptions, stack, resourcePath, null, "entry", collection, true);
             return stack.client.InvokeSync(service);
         }
 
@@ -338,7 +337,7 @@ namespace Contentstack.Management.Core.Models
 
             collection.Add("locale", locale);
 
-            var service = new LocalizationService<IEntry>(stack.client.serializer, stack, resourcePath, null, "entry", collection, true);
+            var service = new LocalizationService<IEntry>(stack.client.SerializerOptions, stack, resourcePath, null, "entry", collection, true);
             return stack.client.InvokeAsync<LocalizationService<IEntry>, ContentstackResponse>(service);
         }
 
@@ -357,7 +356,7 @@ namespace Contentstack.Management.Core.Models
             stack.ThrowIfNotLoggedIn();
             ThrowIfUidEmpty();
 
-            var service = new LocaleService(stack.client.serializer, stack, resourcePath);
+            var service = new LocaleService(stack.client.SerializerOptions, stack, resourcePath);
             return stack.client.InvokeSync(service);
         }
 
@@ -376,7 +375,7 @@ namespace Contentstack.Management.Core.Models
             stack.ThrowIfNotLoggedIn();
             ThrowIfUidEmpty();
 
-            var service = new LocaleService(stack.client.serializer, stack, resourcePath);
+            var service = new LocaleService(stack.client.SerializerOptions, stack, resourcePath);
             return stack.client.InvokeAsync<LocaleService, ContentstackResponse>(service);
         }
 
@@ -395,7 +394,7 @@ namespace Contentstack.Management.Core.Models
             stack.ThrowIfNotLoggedIn();
             ThrowIfUidEmpty();
 
-            var service = new FetchReferencesService(stack.client.serializer, stack, resourcePath, collection: collection);
+            var service = new FetchReferencesService(stack, resourcePath, collection: collection, stjOptions: stack.client.SerializerOptions);
             return stack.client.InvokeSync(service);
         }
 
@@ -414,7 +413,7 @@ namespace Contentstack.Management.Core.Models
             stack.ThrowIfNotLoggedIn();
             ThrowIfUidEmpty();
 
-            var service = new FetchReferencesService(stack.client.serializer, stack, resourcePath, collection: collection);
+            var service = new FetchReferencesService(stack, resourcePath, collection: collection, stjOptions: stack.client.SerializerOptions);
             return stack.client.InvokeAsync<FetchReferencesService, ContentstackResponse>(service);
         }
 
@@ -435,7 +434,7 @@ namespace Contentstack.Management.Core.Models
             stack.ThrowIfNotLoggedIn();
             ThrowIfUidEmpty();
 
-            var service = new PublishUnpublishService(stack.client.serializer, stack, details, $"{resourcePath}/publish", "entry", locale);
+            var service = new PublishUnpublishService(stack, details, $"{resourcePath}/publish", "entry", locale, stjOptions: stack.client.SerializerOptions);
             return stack.client.InvokeSync(service, apiVersion: apiVersion);
         }
 
@@ -456,7 +455,7 @@ namespace Contentstack.Management.Core.Models
             stack.ThrowIfNotLoggedIn();
             ThrowIfUidEmpty();
 
-            var service = new PublishUnpublishService(stack.client.serializer, stack, details, $"{resourcePath}/publish", "entry", locale);
+            var service = new PublishUnpublishService(stack, details, $"{resourcePath}/publish", "entry", locale, stjOptions: stack.client.SerializerOptions);
             return stack.client.InvokeAsync<PublishUnpublishService, ContentstackResponse>(service, apiVersion: apiVersion);
         }
 
@@ -477,7 +476,7 @@ namespace Contentstack.Management.Core.Models
             stack.ThrowIfNotLoggedIn();
             ThrowIfUidEmpty();
 
-            var service = new PublishUnpublishService(stack.client.serializer, stack, details, $"{resourcePath}/unpublish", "entry", locale);
+            var service = new PublishUnpublishService(stack, details, $"{resourcePath}/unpublish", "entry", locale, stjOptions: stack.client.SerializerOptions);
             return stack.client.InvokeSync(service, apiVersion: apiVersion);
         }
 
@@ -498,7 +497,7 @@ namespace Contentstack.Management.Core.Models
             stack.ThrowIfNotLoggedIn();
             ThrowIfUidEmpty();
 
-            var service = new PublishUnpublishService(stack.client.serializer, stack, details, $"{resourcePath}/unpublish", "entry", locale);
+            var service = new PublishUnpublishService(stack, details, $"{resourcePath}/unpublish", "entry", locale, stjOptions: stack.client.SerializerOptions);
             return stack.client.InvokeAsync<PublishUnpublishService, ContentstackResponse>(service, apiVersion: apiVersion);
         }
 
@@ -520,7 +519,7 @@ namespace Contentstack.Management.Core.Models
             stack.ThrowIfNotLoggedIn();
 
             var text = File.ReadAllText(filePath);
-            var service = new ImportExportService(stack.client.serializer, stack, resourcePath, true, "POST", collection);
+            var service = new ImportExportService(stack.client.SerializerOptions, stack, resourcePath, true, "POST", collection);
             service.ByteContent = System.Text.Encoding.UTF8.GetBytes(text);
 
             return stack.client.InvokeSync(service);
@@ -545,7 +544,7 @@ namespace Contentstack.Management.Core.Models
             ThrowIfUidEmpty();
 
             var text = File.ReadAllText(filePath);
-            var service = new ImportExportService(stack.client.serializer, stack, resourcePath, isImport: true, "POST", collection);
+            var service = new ImportExportService(stack.client.SerializerOptions, stack, resourcePath, isImport: true, "POST", collection);
             service.ByteContent = System.Text.Encoding.UTF8.GetBytes(text);
             return stack.client.InvokeAsync<ImportExportService, ContentstackResponse>(service);
         }
@@ -569,16 +568,13 @@ namespace Contentstack.Management.Core.Models
 
             try
             {
-                var service = new ImportExportService(stack.client.serializer, stack, resourcePath, collection: collection);
+                var service = new ImportExportService(stack.client.SerializerOptions, stack, resourcePath, collection: collection);
                 ContentstackResponse response = stack.client.InvokeSync(service);
                 if (response.IsSuccessStatusCode)
                 {
-                    using (StreamWriter file = File.CreateText(filePath))
-                    using (JsonTextWriter writer = new JsonTextWriter(file))
-                    {
-                        JObject json = response.OpenJObjectResponse();
-                        json.WriteTo(writer);
-                    }
+                    var json = response.OpenJsonObjectResponse();
+                    var opts = new JsonSerializerOptions { WriteIndented = true };
+                    File.WriteAllText(filePath, json.ToJsonString(opts));
                 }
                 return response;
             } catch (Exception e)
@@ -609,7 +605,7 @@ namespace Contentstack.Management.Core.Models
             {
                 { "workflow_stage", model}
             };
-            var service = new CreateUpdateService<Dictionary<string, EntryWorkflowStage>>(stack.client.serializer, stack, $"{resourcePath}/workflow", dict, "workflow", collection: collection);
+            var service = new CreateUpdateService<Dictionary<string, EntryWorkflowStage>>(stack, $"{resourcePath}/workflow", dict, "workflow", collection: collection, stjOptions: stack.client.SerializerOptions);
             return stack.client.InvokeSync(service);
         }
 
@@ -634,7 +630,7 @@ namespace Contentstack.Management.Core.Models
             {
                 { "workflow_stage", model}
             };
-            var service = new CreateUpdateService<Dictionary<string, EntryWorkflowStage>>(stack.client.serializer, stack, $"{resourcePath}/workflow", dict, "workflow", collection: collection);
+            var service = new CreateUpdateService<Dictionary<string, EntryWorkflowStage>>(stack, $"{resourcePath}/workflow", dict, "workflow", collection: collection, stjOptions: stack.client.SerializerOptions);
             return stack.client.InvokeAsync<CreateUpdateService<Dictionary<string, EntryWorkflowStage>>, ContentstackResponse>(service);
         }
 
@@ -659,7 +655,7 @@ namespace Contentstack.Management.Core.Models
             {
                 { "publishing_rule", publishAction}
             };
-            var service = new CreateUpdateService<Dictionary<string, EntryPublishAction>>(stack.client.serializer, stack, $"{resourcePath}/workflow", dict, "workflow", collection: collection);
+            var service = new CreateUpdateService<Dictionary<string, EntryPublishAction>>(stack, $"{resourcePath}/workflow", dict, "workflow", collection: collection, stjOptions: stack.client.SerializerOptions);
             return stack.client.InvokeSync(service);
         }
         /// <summary>
@@ -683,7 +679,7 @@ namespace Contentstack.Management.Core.Models
             {
                 { "publishing_rule", publishAction}
             };
-            var service = new CreateUpdateService<Dictionary<string, EntryPublishAction>>(stack.client.serializer, stack, $"{resourcePath}/workflow", dict, "workflow", collection: collection);
+            var service = new CreateUpdateService<Dictionary<string, EntryPublishAction>>(stack, $"{resourcePath}/workflow", dict, "workflow", collection: collection, stjOptions: stack.client.SerializerOptions);
             return stack.client.InvokeAsync<CreateUpdateService<Dictionary<string, EntryPublishAction>>, ContentstackResponse>(service);
         }
     }

--- a/Contentstack.Management.Core/Models/EntryVariant.cs
+++ b/Contentstack.Management.Core/Models/EntryVariant.cs
@@ -86,7 +86,7 @@ namespace Contentstack.Management.Core.Models
             stack.ThrowIfNotLoggedIn();
             ThrowIfUidEmpty();
 
-            var service = new CreateUpdateService<object>(stack.client.serializer, stack, resourcePath, model, "entry", "PUT", collection: collection);
+            var service = new CreateUpdateService<object>(stack, resourcePath, model, "entry", "PUT", collection: collection, stjOptions: stack.client.SerializerOptions);
             return stack.client.InvokeSync(service);
         }
 
@@ -101,7 +101,7 @@ namespace Contentstack.Management.Core.Models
             stack.ThrowIfNotLoggedIn();
             ThrowIfUidEmpty();
 
-            var service = new CreateUpdateService<object>(stack.client.serializer, stack, resourcePath, model, "entry", "PUT", collection: collection);
+            var service = new CreateUpdateService<object>(stack, resourcePath, model, "entry", "PUT", collection: collection, stjOptions: stack.client.SerializerOptions);
             return stack.client.InvokeAsync<CreateUpdateService<object>, ContentstackResponse>(service);
         }
 
@@ -137,7 +137,7 @@ namespace Contentstack.Management.Core.Models
             stack.ThrowIfNotLoggedIn();
             ThrowIfUidEmpty();
 
-            var service = new FetchDeleteService(stack.client.serializer, stack, resourcePath, collection: collection);
+            var service = new FetchDeleteService(stack, resourcePath, collection: collection);
             return stack.client.InvokeSync(service);
         }
 
@@ -151,7 +151,7 @@ namespace Contentstack.Management.Core.Models
             stack.ThrowIfNotLoggedIn();
             ThrowIfUidEmpty();
 
-            var service = new FetchDeleteService(stack.client.serializer, stack, resourcePath, collection: collection);
+            var service = new FetchDeleteService(stack, resourcePath, collection: collection);
             return stack.client.InvokeAsync<FetchDeleteService, ContentstackResponse>(service);
         }
 
@@ -165,7 +165,7 @@ namespace Contentstack.Management.Core.Models
             stack.ThrowIfNotLoggedIn();
             ThrowIfUidEmpty();
 
-            var service = new FetchDeleteService(stack.client.serializer, stack, resourcePath, "DELETE", collection: collection);
+            var service = new FetchDeleteService(stack, resourcePath, "DELETE", collection: collection);
             return stack.client.InvokeSync(service);
         }
 
@@ -179,7 +179,7 @@ namespace Contentstack.Management.Core.Models
             stack.ThrowIfNotLoggedIn();
             ThrowIfUidEmpty();
 
-            var service = new FetchDeleteService(stack.client.serializer, stack, resourcePath, "DELETE", collection: collection);
+            var service = new FetchDeleteService(stack, resourcePath, "DELETE", collection: collection);
             return stack.client.InvokeAsync<FetchDeleteService, ContentstackResponse>(service);
         }
 

--- a/Contentstack.Management.Core/Models/EntryWorkflowStage.cs
+++ b/Contentstack.Management.Core/Models/EntryWorkflowStage.cs
@@ -1,56 +1,52 @@
 ﻿using System.Collections.Generic;
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 namespace Contentstack.Management.Core.Models
 {
-    [JsonObject(ItemNullValueHandling = NullValueHandling.Ignore)]
     public class EntryWorkflowStage
     {
-        [JsonProperty(propertyName: "uid")]
+        [JsonPropertyName("uid")]
         public string Uid { get; set; }
-        [JsonProperty(propertyName: "comment")]
+        [JsonPropertyName("comment")]
         public string Comment { get; set; }
-        [JsonProperty(propertyName: "due_date")]
+        [JsonPropertyName("due_date")]
         public string DueDate { get; set; }
-        [JsonProperty(propertyName: "notify")]
+        [JsonPropertyName("notify")]
         public bool Notify { get; set; } = true;
-        [JsonProperty(propertyName: "assigned_to")]
-        public List<AssignToUser> AssignedTo;
-        [JsonProperty(propertyName: "assigned_by_roles")]
-        public List<AssignByRole> AssignedByRoles;
+        [JsonPropertyName("assigned_to")]
+        public List<AssignToUser> AssignedTo { get; set; }
+        [JsonPropertyName("assigned_by_roles")]
+        public List<AssignByRole> AssignedByRoles { get; set; }
     }
 
-    [JsonObject(ItemNullValueHandling = NullValueHandling.Ignore)]
     public class AssignToUser
     {
-        [JsonProperty(propertyName: "uid")]
+        [JsonPropertyName("uid")]
         public string Uid { get; set; }
-        [JsonProperty(propertyName: "name")]
+        [JsonPropertyName("name")]
         public string Name { get; set; }
-        [JsonProperty(propertyName: "email")]
+        [JsonPropertyName("email")]
         public string Email { get; set; }
     }
 
-    [JsonObject(ItemNullValueHandling = NullValueHandling.Ignore)]
     public class AssignByRole
     {
-        [JsonProperty(propertyName: "uid")]
+        [JsonPropertyName("uid")]
         public string Uid { get; set; }
-        [JsonProperty(propertyName: "name")]
+        [JsonPropertyName("name")]
         public string Name { get; set; }
     }
 
-    [JsonObject(ItemNullValueHandling = NullValueHandling.Ignore)]
     public class EntryPublishAction
     {
-        [JsonProperty(propertyName: "uid")]
+        [JsonPropertyName("uid")]
         public string Uid { get; set; }
-        [JsonProperty(propertyName: "action")]
+        [JsonPropertyName("action")]
         public string Action { get; set; }
-        [JsonProperty(propertyName: "comment")]
+        [JsonPropertyName("comment")]
         public string Comment { get; set; }
-        [JsonProperty(propertyName: "notify")]
+        [JsonPropertyName("notify")]
         public bool Notify { get; set; } = true;
-        [JsonProperty(propertyName: "status")]
+        [JsonPropertyName("status")]
         public int Status { get; set; }
 
     }

--- a/Contentstack.Management.Core/Models/Node.cs
+++ b/Contentstack.Management.Core/Models/Node.cs
@@ -1,10 +1,8 @@
 ﻿using System.Collections.Generic;
 using Contentstack.Management.Core.Utils;
-using Newtonsoft.Json;
 
 namespace Contentstack.Management.Core.Models
 {
-    [JsonConverter(typeof(NodeJsonConverter))]
     public class Node
     {
         public string type { get; set; }

--- a/Contentstack.Management.Core/Models/Stack.cs
+++ b/Contentstack.Management.Core/Models/Stack.cs
@@ -936,7 +936,6 @@ namespace Contentstack.Management.Core.Models
         /// </code></pre>
         /// </example>
         /// <returns>The <see cref="Models.VariantGroup" /></returns>
-        /*
         public VariantGroup VariantGroup(string uid = null)
         {
             ThrowIfNotLoggedIn();
@@ -944,7 +943,6 @@ namespace Contentstack.Management.Core.Models
 
             return new VariantGroup(this, uid);
         }
-        */
 
         /// <summary>
         /// Gets the bulk operation instance for performing bulk operations on entries and assets.

--- a/Contentstack.Management.Core/Models/TextNode.cs
+++ b/Contentstack.Management.Core/Models/TextNode.cs
@@ -1,10 +1,8 @@
 ﻿using System;
-using Newtonsoft.Json;
 using Contentstack.Management.Core.Utils;
 
 namespace Contentstack.Management.Core.Models
 {
-    [JsonConverter(typeof(TextNodeJsonConverter))]
     public class TextNode: Node
     {
         public bool bold { get; set; }

--- a/Contentstack.Management.Core/Models/VariantGroup.cs
+++ b/Contentstack.Management.Core/Models/VariantGroup.cs
@@ -108,7 +108,7 @@ namespace Contentstack.Management.Core.Models
             ThrowIfUidEmpty();
 
             var service = new VariantContentTypeLinkService(
-                stack.client.serializer,
+                stack.client.SerializerOptions,
                 stack,
                 $"{resourcePath}/variants",
                 contentTypeUids,
@@ -142,7 +142,7 @@ namespace Contentstack.Management.Core.Models
             ThrowIfUidEmpty();
 
             var service = new VariantContentTypeLinkService(
-                stack.client.serializer,
+                stack.client.SerializerOptions,
                 stack,
                 $"{resourcePath}/variants",
                 contentTypeUids,
@@ -178,7 +178,7 @@ namespace Contentstack.Management.Core.Models
             ThrowIfUidEmpty();
 
             var service = new VariantContentTypeLinkService(
-                stack.client.serializer,
+                stack.client.SerializerOptions,
                 stack,
                 $"{resourcePath}/variants",
                 contentTypeUids,
@@ -212,7 +212,7 @@ namespace Contentstack.Management.Core.Models
             ThrowIfUidEmpty();
 
             var service = new VariantContentTypeLinkService(
-                stack.client.serializer,
+                stack.client.SerializerOptions,
                 stack,
                 $"{resourcePath}/variants",
                 contentTypeUids,

--- a/Contentstack.Management.Core/Services/Models/ImportExportService.cs
+++ b/Contentstack.Management.Core/Services/Models/ImportExportService.cs
@@ -1,14 +1,14 @@
 ﻿using System;
 using Contentstack.Management.Core.Queryable;
-using Newtonsoft.Json;
+using System.Text.Json;
 using Contentstack.Management.Core.Utils;
 
 namespace Contentstack.Management.Core.Services.Models
 {
     internal class ImportExportService : ContentstackService
     {
-        internal ImportExportService(JsonSerializer serializer, Core.Models.Stack stack, string resourcePath, bool isImport = false, string httpMethod = "GET", ParameterCollection collection = null)
-            : base(serializer, stack: stack, collection: collection)
+        internal ImportExportService(JsonSerializerOptions serializerOptions, Core.Models.Stack stack, string resourcePath, bool isImport = false, string httpMethod = "GET", ParameterCollection collection = null)
+            : base(serializerOptions, stack: stack, collection: collection)
         {
             if (stack.APIKey == null)
             {

--- a/Contentstack.Management.Core/Services/Models/LocaleService.cs
+++ b/Contentstack.Management.Core/Services/Models/LocaleService.cs
@@ -1,13 +1,13 @@
 ﻿using System;
-using Newtonsoft.Json;
+using System.Text.Json;
 using Contentstack.Management.Core.Utils;
 
 namespace Contentstack.Management.Core.Services.Models
 {
     internal class LocaleService: ContentstackService
     {
-        internal LocaleService(JsonSerializer serializer, Core.Models.Stack stack, string resourcePath = null)
-           : base(serializer, stack: stack)
+        internal LocaleService(JsonSerializerOptions serializerOptions, Core.Models.Stack stack, string resourcePath = null)
+           : base(serializerOptions, stack: stack)
         {
             if (stack.APIKey == null)
             {

--- a/Contentstack.Management.Core/Services/Models/LocalizationService.cs
+++ b/Contentstack.Management.Core/Services/Models/LocalizationService.cs
@@ -1,8 +1,7 @@
 ﻿using System;
-using System.Globalization;
-using System.IO;
+using System.Collections.Generic;
+using System.Text.Json;
 using Contentstack.Management.Core.Queryable;
-using Newtonsoft.Json;
 using Contentstack.Management.Core.Utils;
 
 namespace Contentstack.Management.Core.Services.Models
@@ -14,8 +13,8 @@ namespace Contentstack.Management.Core.Services.Models
         private readonly bool _shouldUnlocalize;
         #region Internal
 
-        internal LocalizationService(JsonSerializer serializer, Core.Models.Stack stack, string resourcePath, T dataModel, string fieldName, ParameterCollection collection = null, bool shouldUnlocalize = false)
-            : base(serializer, stack: stack, collection)
+        internal LocalizationService(JsonSerializerOptions serializerOptions, Core.Models.Stack stack, string resourcePath, T dataModel, string fieldName, ParameterCollection collection = null, bool shouldUnlocalize = false)
+            : base(serializerOptions, stack: stack, collection)
         {
             if (stack.APIKey == null)
             {
@@ -49,16 +48,9 @@ namespace Contentstack.Management.Core.Services.Models
         {
             if (!_shouldUnlocalize)
             {
-                using (StringWriter stringWriter = new StringWriter(CultureInfo.InvariantCulture))
-                {
-                    JsonWriter writer = new JsonTextWriter(stringWriter);
-
-                    Serializer.Serialize(writer, _typedModel);
-                    string snippet = $"{{\"{_fieldName}\": {stringWriter.ToString()}}}";
-                    this.ByteContent = System.Text.Encoding.UTF8.GetBytes(snippet);
-                }
+                var wrapper = new Dictionary<string, T> { { _fieldName, _typedModel } };
+                this.ByteContent = JsonSerializer.SerializeToUtf8Bytes(wrapper, SerializerOptions);
             }
-            
         }
     }
 }

--- a/Contentstack.Management.Core/Services/Models/VariantContentTypeLinkService.cs
+++ b/Contentstack.Management.Core/Services/Models/VariantContentTypeLinkService.cs
@@ -1,9 +1,8 @@
 using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.IO;
+using System.Text.Json;
 using Contentstack.Management.Core.Queryable;
-using Newtonsoft.Json;
 
 namespace Contentstack.Management.Core.Services.Models
 {
@@ -14,7 +13,7 @@ namespace Contentstack.Management.Core.Services.Models
         private readonly bool _isLink;
 
         internal VariantContentTypeLinkService(
-            JsonSerializer serializer,
+            JsonSerializerOptions serializerOptions,
             Core.Models.Stack stack,
             string resourcePath,
             List<string> contentTypeUids,
@@ -22,7 +21,7 @@ namespace Contentstack.Management.Core.Services.Models
             bool isLink,
             ParameterCollection collection = null
         )
-            : base(serializer, stack: stack, collection: collection)
+            : base(serializerOptions, stack, collection)
         {
             if (stack.APIKey == null)
             {
@@ -60,9 +59,9 @@ namespace Contentstack.Management.Core.Services.Models
 
         public override void ContentBody()
         {
-            using (StringWriter stringWriter = new StringWriter(CultureInfo.InvariantCulture))
+            using var ms = new MemoryStream();
+            using (var writer = new Utf8JsonWriter(ms))
             {
-                JsonWriter writer = new JsonTextWriter(stringWriter);
                 writer.WriteStartObject();
                 
                 writer.WritePropertyName("content_types");
@@ -70,26 +69,22 @@ namespace Contentstack.Management.Core.Services.Models
                 foreach (var uid in _contentTypeUids)
                 {
                     writer.WriteStartObject();
-                    writer.WritePropertyName("uid");
-                    writer.WriteValue(uid);
-                    writer.WritePropertyName("status");
-                    writer.WriteValue(_isLink ? "linked" : "unlinked");
+                    writer.WriteString("uid", uid);
+                    writer.WriteString("status", _isLink ? "linked" : "unlinked");
                     writer.WriteEndObject();
                 }
                 writer.WriteEndArray();
 
-                writer.WritePropertyName("uid");
-                writer.WriteValue(_variantGroupUid);
+                writer.WriteString("uid", _variantGroupUid);
 
                 writer.WritePropertyName("branches");
                 writer.WriteStartArray();
-                writer.WriteValue("main");
+                writer.WriteStringValue("main");
                 writer.WriteEndArray();
 
                 writer.WriteEndObject();
-
-                this.ByteContent = System.Text.Encoding.UTF8.GetBytes(stringWriter.ToString());
             }
+            this.ByteContent = ms.ToArray();
         }
     }
 }

--- a/Contentstack.Management.Core/contentstack.management.core.csproj
+++ b/Contentstack.Management.Core/contentstack.management.core.csproj
@@ -87,8 +87,7 @@
     <!-- BulkOperation.cs - RE-ENABLED -->
     <!-- ContentModelling.cs - RE-ENABLED for ContentType -->
     <!-- ContentType.cs - RE-ENABLED -->
-    <Compile Remove="Models\Entry.cs" />
-    <Compile Remove="Models\EntryVariant.cs" />
+    <!-- Entry.cs, EntryVariant.cs - RE-ENABLED for Entry module STJ migration -->
     <!-- Environment.cs - RE-ENABLED for Environment module STJ migration -->
     <Compile Remove="Models\Extension.cs" />
     <!-- Folder.cs - RE-ENABLED for Assets module -->
@@ -104,7 +103,7 @@
     <Compile Remove="Models\Taxonomy.cs" />
     <Compile Remove="Models\Term.cs" />
     <!-- User.cs - RE-ENABLED -->
-    <Compile Remove="Models\VariantGroup.cs" />
+    <!-- Models\VariantGroup.cs - RE-ENABLED for VariantGroup module STJ migration -->
     <!-- Version.cs - RE-ENABLED for Assets module -->
     <Compile Remove="Models\Webhook.cs" />
     <Compile Remove="Models\Workflow.cs" />
@@ -126,11 +125,9 @@
     <!-- QueryService.cs - RE-ENABLED for ContentType listing -->
     <!-- Re-enable essential model services for ContentType -->
     <!-- GlobalFieldService.cs, GlobalFieldFetchDeleteService.cs - RE-ENABLED for Global Field module STJ migration -->
-    <Compile Remove="Services\Models\ImportExportService.cs" />
-    <Compile Remove="Services\Models\LocaleService.cs" />
-    <Compile Remove="Services\Models\LocalizationService.cs" />
+    <!-- ImportExportService.cs, LocaleService.cs, LocalizationService.cs - RE-ENABLED for Entry module STJ migration -->
     <!-- FetchReferencesService, CreateUpdateFolderService, UploadService, PublishUnpublishService - RE-ENABLED for Assets module -->
-    <Compile Remove="Services\Models\VariantContentTypeLinkService.cs" />
+    <!-- Services\Models\VariantContentTypeLinkService.cs - RE-ENABLED for VariantGroup module STJ migration -->
     <!-- Versioning services - RE-ENABLED for Assets module -->
     <!-- <Compile Remove="Services\Models\Versioning\**\*.cs" /> -->
     <!-- CreateUpdateService, FetchDeleteService, DeleteService - RE-ENABLED for ContentType -->

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <Version>1.0.0-beta.5</Version>
+    <Version>1.0.0-beta.6</Version>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
**Summary**
Migrates three core SDK modules from Newtonsoft.Json to System.Text.Json as part of the ongoing STJ migration effort.

**Modules Migrated**
- **Entry Module**: CRUD operations, publishing, versioning
- **Entry Variant Module**: Variant creation, fetching, publishing, deletion  
- **Variant Group Module**: Discovery, content type linking/unlinking

**Technical Changes**
- Migrated `VariantContentTypeLinkService` from `JsonTextWriter` to `Utf8JsonWriter`
- Updated service constructors to use `JsonSerializerOptions` instead of `JsonSerializer`
- Re-enabled `Stack.VariantGroup()` method by uncommenting implementation
- Removed build exclusions for `VariantGroup.cs` and `VariantContentTypeLinkService.cs`
- Updated all variant group service calls to use `SerializerOptions` property

**Files Modified**
- `Models/VariantGroup.cs` - Updated serializer parameter usage
- `Services/Models/VariantContentTypeLinkService.cs` - Converted to STJ serialization
- `Models/Stack.cs` - Re-enabled VariantGroup() factory method
- `contentstack.management.core.csproj` - Removed compile exclusions

**API Compatibility**
No breaking changes to public API surface. All existing method signatures remain unchanged.

**Version Bump**
`1.0.0-beta.5` → `1.0.0-beta.6`