### PR TITLE
fix: resolve 48 transitive Snyk license issues in test projects

### DIFF
--- a/Contentstack.Management.Core.Tests/Contentstack.Management.Core.Tests.csproj
+++ b/Contentstack.Management.Core.Tests/Contentstack.Management.Core.Tests.csproj
@@ -26,6 +26,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.3.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
+    <PackageReference Include="Microsoft.NETCore.Platforms" Version="7.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Contentstack.Management.Core.Unit.Tests/Contentstack.Management.Core.Unit.Tests.csproj
+++ b/Contentstack.Management.Core.Unit.Tests/Contentstack.Management.Core.Unit.Tests.csproj
@@ -21,6 +21,8 @@
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.3.0" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
+
+    <PackageReference Include="Microsoft.NETCore.Platforms" Version="7.0.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- Explicitly added Microsoft.NETCore.Platforms v7.0.0 to test projects
- Overrides legacy Microsoft-.NET-Library licensed version (1.1.1) introduced via AutoFixture -> Fare -> NETStandard.Library
- Resolves Snyk compliance tracking without altering runtime dependencies