### PR TITLE
feat: taxonomy publish/unpublish/unlocalize + terms unlocalize

### DIFF
--- a/Contentstack.Management.Core.Tests/IntegrationTest/Contentstack017_TaxonomyTest.cs
+++ b/Contentstack.Management.Core.Tests/IntegrationTest/Contentstack017_TaxonomyTest.cs
@@ -6492,6 +6492,249 @@ namespace Contentstack.Management.Core.Tests.IntegrationTest
             }
         }
 
+        [TestMethod]
+        public void Test280_Should_Publish_Taxonomy()
+        {
+            TestOutputLogger.LogContext("TestScenario", "Test280_Should_Publish_Taxonomy");
+            if (string.IsNullOrEmpty(_testLocaleCode))
+            {
+                AssertLogger.Inconclusive("No non-master locale available; skipping publish test.");
+                return;
+            }
+
+            // Look up an environment from the stack to use as a publish target.
+            ContentstackResponse envResp = _stack.Environments().Query().Find();
+            if (!envResp.IsSuccessStatusCode)
+            {
+                AssertLogger.Inconclusive("Could not fetch environments; skipping publish test.");
+                return;
+            }
+            var envJson = envResp.OpenJsonObjectResponse();
+            var envArray = envJson["environments"] as System.Text.Json.Nodes.JsonArray;
+            if (envArray == null || envArray.Count == 0)
+            {
+                AssertLogger.Inconclusive("No environments on stack; skipping publish test.");
+                return;
+            }
+            string envName = envArray[0]?["name"]?.ToString();
+            if (string.IsNullOrEmpty(envName))
+            {
+                AssertLogger.Inconclusive("Could not read environment name; skipping publish test.");
+                return;
+            }
+
+            var model = new TaxonomyPublishModel
+            {
+                Locales = new List<string> { _testLocaleCode },
+                Environments = new List<string> { envName },
+                Items = new List<TaxonomyPublishItem> { new TaxonomyPublishItem { Uid = _taxonomyUid } }
+            };
+            ContentstackResponse response = _stack.Taxonomy().Publish(model);
+            // 403 = taxonomy_publish feature not enabled on this stack — treat as inconclusive.
+            if (response.StatusCode == System.Net.HttpStatusCode.Forbidden)
+            {
+                AssertLogger.Inconclusive("taxonomy_publish feature not enabled on this stack; skipping.");
+                return;
+            }
+            AssertLogger.IsTrue(response.IsSuccessStatusCode, $"Publish failed: {response.OpenResponse()}", "PublishTaxonomySuccess");
+        }
+
+        [TestMethod]
+        public async Task Test281_Should_Publish_Taxonomy_Async()
+        {
+            TestOutputLogger.LogContext("TestScenario", "Test281_Should_Publish_Taxonomy_Async");
+            if (string.IsNullOrEmpty(_testLocaleCode))
+            {
+                AssertLogger.Inconclusive("No non-master locale available; skipping async publish test.");
+                return;
+            }
+
+            ContentstackResponse envResp = _stack.Environments().Query().Find();
+            if (!envResp.IsSuccessStatusCode) { AssertLogger.Inconclusive("Could not fetch environments."); return; }
+            var envArray = envResp.OpenJsonObjectResponse()["environments"] as System.Text.Json.Nodes.JsonArray;
+            if (envArray == null || envArray.Count == 0) { AssertLogger.Inconclusive("No environments on stack."); return; }
+            string envName = envArray[0]?["name"]?.ToString();
+            if (string.IsNullOrEmpty(envName)) { AssertLogger.Inconclusive("Could not read environment name."); return; }
+
+            var model = new TaxonomyPublishModel
+            {
+                Locales = new List<string> { _testLocaleCode },
+                Environments = new List<string> { envName },
+                Items = new List<TaxonomyPublishItem> { new TaxonomyPublishItem { Uid = _taxonomyUid } }
+            };
+            ContentstackResponse response = await _stack.Taxonomy().PublishAsync(model);
+            if (response.StatusCode == System.Net.HttpStatusCode.Forbidden)
+            {
+                AssertLogger.Inconclusive("taxonomy_publish feature not enabled on this stack; skipping.");
+                return;
+            }
+            AssertLogger.IsTrue(response.IsSuccessStatusCode, $"PublishAsync failed: {response.OpenResponse()}", "PublishTaxonomyAsyncSuccess");
+        }
+
+        [TestMethod]
+        public void Test282_Should_Unpublish_Taxonomy()
+        {
+            TestOutputLogger.LogContext("TestScenario", "Test282_Should_Unpublish_Taxonomy");
+            if (string.IsNullOrEmpty(_testLocaleCode))
+            {
+                AssertLogger.Inconclusive("No non-master locale available; skipping unpublish test.");
+                return;
+            }
+
+            ContentstackResponse envResp = _stack.Environments().Query().Find();
+            if (!envResp.IsSuccessStatusCode) { AssertLogger.Inconclusive("Could not fetch environments."); return; }
+            var envArray = envResp.OpenJsonObjectResponse()["environments"] as System.Text.Json.Nodes.JsonArray;
+            if (envArray == null || envArray.Count == 0) { AssertLogger.Inconclusive("No environments on stack."); return; }
+            string envName = envArray[0]?["name"]?.ToString();
+            if (string.IsNullOrEmpty(envName)) { AssertLogger.Inconclusive("Could not read environment name."); return; }
+
+            var model = new TaxonomyPublishModel
+            {
+                Locales = new List<string> { _testLocaleCode },
+                Environments = new List<string> { envName },
+                Items = new List<TaxonomyPublishItem> { new TaxonomyPublishItem { Uid = _taxonomyUid } }
+            };
+            ContentstackResponse response = _stack.Taxonomy().Unpublish(model);
+            if (response.StatusCode == System.Net.HttpStatusCode.Forbidden)
+            {
+                AssertLogger.Inconclusive("taxonomy_publish feature not enabled on this stack; skipping.");
+                return;
+            }
+            AssertLogger.IsTrue(response.IsSuccessStatusCode, $"Unpublish failed: {response.OpenResponse()}", "UnpublishTaxonomySuccess");
+        }
+
+        [TestMethod]
+        public async Task Test283_Should_Unpublish_Taxonomy_Async()
+        {
+            TestOutputLogger.LogContext("TestScenario", "Test283_Should_Unpublish_Taxonomy_Async");
+            if (string.IsNullOrEmpty(_testLocaleCode))
+            {
+                AssertLogger.Inconclusive("No non-master locale available; skipping async unpublish test.");
+                return;
+            }
+
+            ContentstackResponse envResp = _stack.Environments().Query().Find();
+            if (!envResp.IsSuccessStatusCode) { AssertLogger.Inconclusive("Could not fetch environments."); return; }
+            var envArray = envResp.OpenJsonObjectResponse()["environments"] as System.Text.Json.Nodes.JsonArray;
+            if (envArray == null || envArray.Count == 0) { AssertLogger.Inconclusive("No environments on stack."); return; }
+            string envName = envArray[0]?["name"]?.ToString();
+            if (string.IsNullOrEmpty(envName)) { AssertLogger.Inconclusive("Could not read environment name."); return; }
+
+            var model = new TaxonomyPublishModel
+            {
+                Locales = new List<string> { _testLocaleCode },
+                Environments = new List<string> { envName },
+                Items = new List<TaxonomyPublishItem> { new TaxonomyPublishItem { Uid = _taxonomyUid } }
+            };
+            ContentstackResponse response = await _stack.Taxonomy().UnpublishAsync(model);
+            if (response.StatusCode == System.Net.HttpStatusCode.Forbidden)
+            {
+                AssertLogger.Inconclusive("taxonomy_publish feature not enabled on this stack; skipping.");
+                return;
+            }
+            AssertLogger.IsTrue(response.IsSuccessStatusCode, $"UnpublishAsync failed: {response.OpenResponse()}", "UnpublishTaxonomyAsyncSuccess");
+        }
+
+        [TestMethod]
+        public void Test284_Should_Unlocalize_Taxonomy()
+        {
+            TestOutputLogger.LogContext("TestScenario", "Test284_Should_Unlocalize_Taxonomy");
+            if (string.IsNullOrEmpty(_testLocaleCode))
+            {
+                AssertLogger.Inconclusive("No non-master locale available; skipping taxonomy unlocalize test.");
+                return;
+            }
+
+            // Ensure the taxonomy is localized first so unlocalize has something to remove.
+            var localizeModel = new TaxonomyModel { Name = "Taxonomy For Unlocalize" };
+            var localizeColl = new ParameterCollection();
+            localizeColl.Add("locale", _testLocaleCode);
+            _stack.Taxonomy(_taxonomyUid).Localize(localizeModel, localizeColl);
+
+            ContentstackResponse response = _stack.Taxonomy(_taxonomyUid).Unlocalize(_testLocaleCode);
+            AssertLogger.IsTrue(response.IsSuccessStatusCode, $"Unlocalize failed: {response.OpenResponse()}", "UnlocalizeTaxonomySuccess");
+        }
+
+        [TestMethod]
+        public async Task Test285_Should_Unlocalize_Taxonomy_Async()
+        {
+            TestOutputLogger.LogContext("TestScenario", "Test285_Should_Unlocalize_Taxonomy_Async");
+            if (string.IsNullOrEmpty(_asyncTestLocaleCode))
+            {
+                AssertLogger.Inconclusive("No second non-master locale available; skipping async unlocalize test.");
+                return;
+            }
+
+            var localizeModel = new TaxonomyModel { Name = "Taxonomy For Unlocalize Async" };
+            var localizeColl = new ParameterCollection();
+            localizeColl.Add("locale", _asyncTestLocaleCode);
+            await _stack.Taxonomy(_taxonomyUid).LocalizeAsync(localizeModel, localizeColl);
+
+            ContentstackResponse response = await _stack.Taxonomy(_taxonomyUid).UnlocalizeAsync(_asyncTestLocaleCode);
+            AssertLogger.IsTrue(response.IsSuccessStatusCode, $"UnlocalizeAsync failed: {response.OpenResponse()}", "UnlocalizeTaxonomyAsyncSuccess");
+        }
+
+        [TestMethod]
+        public void Test286_Should_Unlocalize_Term()
+        {
+            TestOutputLogger.LogContext("TestScenario", "Test286_Should_Unlocalize_Term");
+            if (string.IsNullOrEmpty(_testLocaleCode) || string.IsNullOrEmpty(_rootTermUid))
+            {
+                AssertLogger.Inconclusive("No non-master locale or root term available; skipping term unlocalize test.");
+                return;
+            }
+
+            // Localize the term first so unlocalize has something to remove.
+            var localizeModel = new TermModel { Name = "Root Term For Unlocalize" };
+            var localizeColl = new ParameterCollection();
+            localizeColl.Add("locale", _testLocaleCode);
+            _stack.Taxonomy(_taxonomyUid).Terms(_rootTermUid).Localize(localizeModel, localizeColl);
+
+            ContentstackResponse response = _stack.Taxonomy(_taxonomyUid).Terms(_rootTermUid).Unlocalize(_testLocaleCode);
+            AssertLogger.IsTrue(response.IsSuccessStatusCode, $"Term Unlocalize failed: {response.OpenResponse()}", "UnlocalizeTermSuccess");
+        }
+
+        [TestMethod]
+        public async Task Test287_Should_Unlocalize_Term_Async()
+        {
+            TestOutputLogger.LogContext("TestScenario", "Test287_Should_Unlocalize_Term_Async");
+            if (string.IsNullOrEmpty(_asyncTestLocaleCode) || string.IsNullOrEmpty(_rootTermUid))
+            {
+                AssertLogger.Inconclusive("No second non-master locale or root term available; skipping async term unlocalize test.");
+                return;
+            }
+
+            var localizeModel = new TermModel { Name = "Root Term For Unlocalize Async" };
+            var localizeColl = new ParameterCollection();
+            localizeColl.Add("locale", _asyncTestLocaleCode);
+            await _stack.Taxonomy(_taxonomyUid).Terms(_rootTermUid).LocalizeAsync(localizeModel, localizeColl);
+
+            ContentstackResponse response = await _stack.Taxonomy(_taxonomyUid).Terms(_rootTermUid).UnlocalizeAsync(_asyncTestLocaleCode);
+            AssertLogger.IsTrue(response.IsSuccessStatusCode, $"Term UnlocalizeAsync failed: {response.OpenResponse()}", "UnlocalizeTermAsyncSuccess");
+        }
+
+        [TestMethod]
+        public void Test288_Should_Throw_When_Publish_With_Uid_Set()
+        {
+            TestOutputLogger.LogContext("TestScenario", "Test288_Should_Throw_When_Publish_With_Uid_Set");
+            var model = new TaxonomyPublishModel
+            {
+                Locales = new List<string> { "en-us" },
+                Environments = new List<string> { "development" },
+                Items = new List<TaxonomyPublishItem> { new TaxonomyPublishItem { Uid = _taxonomyUid } }
+            };
+            AssertLogger.ThrowsException<InvalidOperationException>(
+                () => _stack.Taxonomy(_taxonomyUid).Publish(model), "PublishWithUidSet");
+        }
+
+        [TestMethod]
+        public void Test289_Should_Throw_When_Unlocalize_Without_Uid()
+        {
+            TestOutputLogger.LogContext("TestScenario", "Test289_Should_Throw_When_Unlocalize_Without_Uid");
+            AssertLogger.ThrowsException<ArgumentException>(
+                () => _stack.Taxonomy().Unlocalize("en-us"), "UnlocalizeWithoutUid");
+        }
+
         private static Stack GetStack()
         {
             StackResponse response = StackResponse.getStack(_client.serializer);

--- a/Contentstack.Management.Core.Unit.Tests/Models/TaxonomyTest.cs
+++ b/Contentstack.Management.Core.Unit.Tests/Models/TaxonomyTest.cs
@@ -194,5 +194,94 @@ namespace Contentstack.Management.Core.Unit.Tests.Models
             Assert.IsFalse(response.IsSuccessStatusCode);
             Assert.AreEqual(HttpStatusCode.BadRequest, response.StatusCode);
         }
+
+        [TestMethod]
+        public void Publish_Throws_When_Uid_Is_Set()
+        {
+            var model = new TaxonomyPublishModel { Locales = new System.Collections.Generic.List<string> { "en-us" } };
+            Assert.ThrowsException<InvalidOperationException>(() => _stack.Taxonomy(_fixture.Create<string>()).Publish(model));
+            Assert.ThrowsExceptionAsync<InvalidOperationException>(() => _stack.Taxonomy(_fixture.Create<string>()).PublishAsync(model));
+        }
+
+        [TestMethod]
+        public void Unpublish_Throws_When_Uid_Is_Set()
+        {
+            var model = new TaxonomyPublishModel { Locales = new System.Collections.Generic.List<string> { "en-us" } };
+            Assert.ThrowsException<InvalidOperationException>(() => _stack.Taxonomy(_fixture.Create<string>()).Unpublish(model));
+            Assert.ThrowsExceptionAsync<InvalidOperationException>(() => _stack.Taxonomy(_fixture.Create<string>()).UnpublishAsync(model));
+        }
+
+        [TestMethod]
+        public void Unlocalize_Throws_When_Uid_Is_Empty()
+        {
+            Assert.ThrowsException<ArgumentException>(() => _stack.Taxonomy().Unlocalize("hi-in"));
+            Assert.ThrowsExceptionAsync<ArgumentException>(() => _stack.Taxonomy().UnlocalizeAsync("hi-in"));
+        }
+
+        [TestMethod]
+        public void Should_Publish_Taxonomy()
+        {
+            var model = new TaxonomyPublishModel
+            {
+                Locales = new System.Collections.Generic.List<string> { "en-us" },
+                Environments = new System.Collections.Generic.List<string> { "production" },
+                Items = new System.Collections.Generic.List<TaxonomyPublishItem> { new TaxonomyPublishItem { Uid = "taxonomy_1" } }
+            };
+            ContentstackResponse response = _stack.Taxonomy().Publish(model);
+            Assert.AreEqual(_contentstackResponse.OpenResponse(), response.OpenResponse());
+        }
+
+        [TestMethod]
+        public async System.Threading.Tasks.Task Should_Publish_Taxonomy_Async()
+        {
+            var model = new TaxonomyPublishModel
+            {
+                Locales = new System.Collections.Generic.List<string> { "en-us" },
+                Environments = new System.Collections.Generic.List<string> { "production" },
+                Items = new System.Collections.Generic.List<TaxonomyPublishItem> { new TaxonomyPublishItem { Uid = "taxonomy_1" } }
+            };
+            ContentstackResponse response = await _stack.Taxonomy().PublishAsync(model);
+            Assert.AreEqual(_contentstackResponse.OpenResponse(), response.OpenResponse());
+        }
+
+        [TestMethod]
+        public void Should_Unpublish_Taxonomy()
+        {
+            var model = new TaxonomyPublishModel
+            {
+                Locales = new System.Collections.Generic.List<string> { "en-us" },
+                Environments = new System.Collections.Generic.List<string> { "production" },
+                Items = new System.Collections.Generic.List<TaxonomyPublishItem> { new TaxonomyPublishItem { Uid = "taxonomy_1" } }
+            };
+            ContentstackResponse response = _stack.Taxonomy().Unpublish(model);
+            Assert.AreEqual(_contentstackResponse.OpenResponse(), response.OpenResponse());
+        }
+
+        [TestMethod]
+        public async System.Threading.Tasks.Task Should_Unpublish_Taxonomy_Async()
+        {
+            var model = new TaxonomyPublishModel
+            {
+                Locales = new System.Collections.Generic.List<string> { "en-us" },
+                Environments = new System.Collections.Generic.List<string> { "production" },
+                Items = new System.Collections.Generic.List<TaxonomyPublishItem> { new TaxonomyPublishItem { Uid = "taxonomy_1" } }
+            };
+            ContentstackResponse response = await _stack.Taxonomy().UnpublishAsync(model);
+            Assert.AreEqual(_contentstackResponse.OpenResponse(), response.OpenResponse());
+        }
+
+        [TestMethod]
+        public void Should_Unlocalize_Taxonomy()
+        {
+            ContentstackResponse response = _stack.Taxonomy(_fixture.Create<string>()).Unlocalize("hi-in");
+            Assert.AreEqual(_contentstackResponse.OpenResponse(), response.OpenResponse());
+        }
+
+        [TestMethod]
+        public async System.Threading.Tasks.Task Should_Unlocalize_Taxonomy_Async()
+        {
+            ContentstackResponse response = await _stack.Taxonomy(_fixture.Create<string>()).UnlocalizeAsync("hi-in");
+            Assert.AreEqual(_contentstackResponse.OpenResponse(), response.OpenResponse());
+        }
     }
 }

--- a/Contentstack.Management.Core.Unit.Tests/Models/TermTest.cs
+++ b/Contentstack.Management.Core.Unit.Tests/Models/TermTest.cs
@@ -174,5 +174,31 @@ namespace Contentstack.Management.Core.Unit.Tests.Models
             Assert.ThrowsException<ArgumentException>(() => _stack.Taxonomy(taxonomyUid).Terms().Localize(_fixture.Create<TermModel>()));
             Assert.ThrowsExceptionAsync<ArgumentException>(() => _stack.Taxonomy(taxonomyUid).Terms().LocalizeAsync(_fixture.Create<TermModel>()));
         }
+
+        [TestMethod]
+        public void Unlocalize_Throws_When_Term_Uid_Is_Empty()
+        {
+            string taxonomyUid = _fixture.Create<string>();
+            Assert.ThrowsException<ArgumentException>(() => _stack.Taxonomy(taxonomyUid).Terms().Unlocalize("hi-in"));
+            Assert.ThrowsExceptionAsync<ArgumentException>(() => _stack.Taxonomy(taxonomyUid).Terms().UnlocalizeAsync("hi-in"));
+        }
+
+        [TestMethod]
+        public void Should_Unlocalize_Term()
+        {
+            string taxonomyUid = _fixture.Create<string>();
+            string termUid = _fixture.Create<string>();
+            ContentstackResponse response = _stack.Taxonomy(taxonomyUid).Terms(termUid).Unlocalize("hi-in");
+            Assert.AreEqual(_contentstackResponse.OpenResponse(), response.OpenResponse());
+        }
+
+        [TestMethod]
+        public async System.Threading.Tasks.Task Should_Unlocalize_Term_Async()
+        {
+            string taxonomyUid = _fixture.Create<string>();
+            string termUid = _fixture.Create<string>();
+            ContentstackResponse response = await _stack.Taxonomy(taxonomyUid).Terms(termUid).UnlocalizeAsync("hi-in");
+            Assert.AreEqual(_contentstackResponse.OpenResponse(), response.OpenResponse());
+        }
     }
 }

--- a/Contentstack.Management.Core/Models/Taxonomy.cs
+++ b/Contentstack.Management.Core/Models/Taxonomy.cs
@@ -185,6 +185,72 @@ namespace Contentstack.Management.Core.Models
         }
 
         /// <summary>
+        /// Publish one or more taxonomies to the specified environments and locales.
+        /// Call on a collection-level instance (no UID set).
+        /// </summary>
+        public ContentstackResponse Publish(TaxonomyPublishModel model, ParameterCollection? collection = null)
+        {
+            stack.ThrowIfNotLoggedIn();
+            ThrowIfUidNotEmpty();
+            return stack.client.InvokeSync(
+                new TaxonomyPublishService<TaxonomyPublishModel>(stack, resourcePath + "/publish", model, collection));
+        }
+
+        /// <summary>Publish one or more taxonomies asynchronously.</summary>
+        public Task<ContentstackResponse> PublishAsync(TaxonomyPublishModel model, ParameterCollection? collection = null)
+        {
+            stack.ThrowIfNotLoggedIn();
+            ThrowIfUidNotEmpty();
+            return stack.client.InvokeAsync<TaxonomyPublishService<TaxonomyPublishModel>, ContentstackResponse>(
+                new TaxonomyPublishService<TaxonomyPublishModel>(stack, resourcePath + "/publish", model, collection));
+        }
+
+        /// <summary>
+        /// Unpublish one or more taxonomies from the specified environments and locales.
+        /// Call on a collection-level instance (no UID set).
+        /// </summary>
+        public ContentstackResponse Unpublish(TaxonomyPublishModel model, ParameterCollection? collection = null)
+        {
+            stack.ThrowIfNotLoggedIn();
+            ThrowIfUidNotEmpty();
+            return stack.client.InvokeSync(
+                new TaxonomyPublishService<TaxonomyPublishModel>(stack, resourcePath + "/unpublish", model, collection));
+        }
+
+        /// <summary>Unpublish one or more taxonomies asynchronously.</summary>
+        public Task<ContentstackResponse> UnpublishAsync(TaxonomyPublishModel model, ParameterCollection? collection = null)
+        {
+            stack.ThrowIfNotLoggedIn();
+            ThrowIfUidNotEmpty();
+            return stack.client.InvokeAsync<TaxonomyPublishService<TaxonomyPublishModel>, ContentstackResponse>(
+                new TaxonomyPublishService<TaxonomyPublishModel>(stack, resourcePath + "/unpublish", model, collection));
+        }
+
+        /// <summary>
+        /// Remove a locale variant of this taxonomy.
+        /// Requires a UID (instance-level). Locale is required.
+        /// </summary>
+        public ContentstackResponse Unlocalize(string locale, ParameterCollection? collection = null)
+        {
+            stack.ThrowIfNotLoggedIn();
+            ThrowIfUidEmpty();
+            var coll = collection ?? new ParameterCollection();
+            coll.Add("locale", locale);
+            return stack.client.InvokeSync(new FetchDeleteService(stack, resourcePath, "DELETE", coll));
+        }
+
+        /// <summary>Remove a locale variant of this taxonomy asynchronously.</summary>
+        public Task<ContentstackResponse> UnlocalizeAsync(string locale, ParameterCollection? collection = null)
+        {
+            stack.ThrowIfNotLoggedIn();
+            ThrowIfUidEmpty();
+            var coll = collection ?? new ParameterCollection();
+            coll.Add("locale", locale);
+            return stack.client.InvokeAsync<FetchDeleteService, ContentstackResponse>(
+                new FetchDeleteService(stack, resourcePath, "DELETE", coll));
+        }
+
+        /// <summary>
         /// Get Terms instance for this taxonomy. When termUid is provided, returns a single-term context; otherwise collection for query/create.
         /// </summary>
         /// <param name="termUid">Optional term UID. If null, returns Terms for querying all terms or creating.</param>

--- a/Contentstack.Management.Core/Models/TaxonomyPublishModel.cs
+++ b/Contentstack.Management.Core/Models/TaxonomyPublishModel.cs
@@ -1,0 +1,34 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace Contentstack.Management.Core.Models
+{
+    /// <summary>
+    /// Request body for bulk taxonomy publish and unpublish operations.
+    /// </summary>
+    public class TaxonomyPublishModel
+    {
+        /// <summary>Target locale codes, e.g. ["en-us", "fr-fr"]. Required.</summary>
+        [JsonPropertyName("locales")]
+        public List<string>? Locales { get; set; }
+
+        /// <summary>Target environment UIDs. Required.</summary>
+        [JsonPropertyName("environments")]
+        public List<string>? Environments { get; set; }
+
+        /// <summary>Taxonomy UIDs to publish/unpublish.</summary>
+        [JsonPropertyName("items")]
+        public List<TaxonomyPublishItem>? Items { get; set; }
+
+        /// <summary>Optional ISO-8601 timestamp for scheduled publishing (Phase 2).</summary>
+        [JsonPropertyName("scheduled_at")]
+        public string? ScheduledAt { get; set; }
+    }
+
+    /// <summary>A single taxonomy item reference in a publish/unpublish request.</summary>
+    public class TaxonomyPublishItem
+    {
+        [JsonPropertyName("uid")]
+        public string? Uid { get; set; }
+    }
+}

--- a/Contentstack.Management.Core/Models/Term.cs
+++ b/Contentstack.Management.Core/Models/Term.cs
@@ -205,6 +205,30 @@ namespace Contentstack.Management.Core.Models
         }
 
         /// <summary>
+        /// Remove a locale variant of this term.
+        /// Requires a UID (instance-level). Locale is required.
+        /// </summary>
+        public ContentstackResponse Unlocalize(string locale, ParameterCollection? collection = null)
+        {
+            stack.ThrowIfNotLoggedIn();
+            ThrowIfUidEmpty();
+            var coll = collection ?? new ParameterCollection();
+            coll.Add("locale", locale);
+            return stack.client.InvokeSync(new FetchDeleteService(stack, resourcePath, "DELETE", coll));
+        }
+
+        /// <summary>Remove a locale variant of this term asynchronously.</summary>
+        public Task<ContentstackResponse> UnlocalizeAsync(string locale, ParameterCollection? collection = null)
+        {
+            stack.ThrowIfNotLoggedIn();
+            ThrowIfUidEmpty();
+            var coll = collection ?? new ParameterCollection();
+            coll.Add("locale", locale);
+            return stack.client.InvokeAsync<FetchDeleteService, ContentstackResponse>(
+                new FetchDeleteService(stack, resourcePath, "DELETE", coll));
+        }
+
+        /// <summary>
         /// Search terms across all taxonomies. GET /taxonomies/$all/terms with typeahead query param. Callable only when no specific term UID is set.
         /// </summary>
         /// <param name="typeahead">Search string for typeahead.</param>

--- a/Contentstack.Management.Core/Services/Models/TaxonomyPublishService.cs
+++ b/Contentstack.Management.Core/Services/Models/TaxonomyPublishService.cs
@@ -1,0 +1,39 @@
+using System;
+using System.Text;
+using System.Text.Json;
+using Contentstack.Management.Core.Queryable;
+using Contentstack.Management.Core.Utils;
+
+namespace Contentstack.Management.Core.Services.Models
+{
+    /// <summary>
+    /// Service for taxonomy publish/unpublish. Serializes the model directly as the root body
+    /// without a field-name wrapper (CreateUpdateService always wraps as {"field": model}).
+    /// </summary>
+    internal class TaxonomyPublishService<T> : ContentstackService
+    {
+        private readonly T _model;
+
+        internal TaxonomyPublishService(Core.Models.Stack stack, string resourcePath, T model, ParameterCollection? collection = null)
+            : base(stack?.client?.SerializerOptions ?? new JsonSerializerOptions(), stack: stack, collection: collection)
+        {
+            if (stack!.APIKey == null)
+                throw new ArgumentNullException("stack", CSConstants.MissingAPIKey);
+            if (resourcePath == null)
+                throw new ArgumentNullException("resourcePath", CSConstants.ResourcePathRequired);
+            if (model == null)
+                throw new ArgumentNullException("model", CSConstants.DataModelRequired);
+
+            ResourcePath = resourcePath;
+            HttpMethod = "POST";
+            if (collection != null && collection.Count > 0)
+                UseQueryString = true;
+            _model = model;
+        }
+
+        public override void ContentBody()
+        {
+            ByteContent = Encoding.UTF8.GetBytes(JsonSerializer.Serialize(_model, SerializerOptions));
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `Publish(model)` / `PublishAsync` to `Taxonomy` — `POST /taxonomies/publish` (collection-level, `ThrowIfUidNotEmpty`)
- Adds `Unpublish(model)` / `UnpublishAsync` to `Taxonomy` — `POST /taxonomies/unpublish` (collection-level, `ThrowIfUidNotEmpty`)
- Adds `Unlocalize(locale)` / `UnlocalizeAsync` to `Taxonomy` — `DELETE /taxonomies/{uid}?locale=` (instance-level, `ThrowIfUidEmpty`)
- Adds `Unlocalize(locale)` / `UnlocalizeAsync` to `Term` — `DELETE .../terms/{uid}?locale=` (instance-level, `ThrowIfUidEmpty`)
- New `TaxonomyPublishModel` (locales, environments, items, scheduled_at)
- New `TaxonomyPublishService<T>` — root-level body serializer (publish/unpublish body is not field-wrapped unlike `CreateUpdateService`)

**Reference:** Java SDK [feat/DX-9676-taxonomy-publish](https://github.com/contentstack/contentstack-management-java/pull/262)  
**TRD:** https://contentstack.atlassian.net/wiki/spaces/CD/pages/3573580300

## Test plan

- [x] `dotnet test --filter "TaxonomyTest|TermTest"` — 44/44 passed
- [x] Guard: `Publish`/`Unpublish` throw `InvalidOperationException` when UID is set
- [x] Guard: `Taxonomy.Unlocalize` / `Term.Unlocalize` throw `ArgumentException` when UID is empty
- [x] Happy-path: `Publish`, `Unpublish`, `Unlocalize` (sync + async) return `ContentstackResponse`

🤖 Generated with [Claude Code](https://claude.com/claude-code)