### PR TITLE
[DX-9678] .NET CMA SDK | Taxonomy publish, unpublish, unlocalize + term unlocalize

### DIFF
--- a/Contentstack.Management.Core.Unit.Tests/Models/TaxonomyTest.cs
+++ b/Contentstack.Management.Core.Unit.Tests/Models/TaxonomyTest.cs
@@ -194,5 +194,108 @@ namespace Contentstack.Management.Core.Unit.Tests.Models
             Assert.IsFalse(response.IsSuccessStatusCode);
             Assert.AreEqual(HttpStatusCode.BadRequest, response.StatusCode);
         }
+
+        [TestMethod]
+        public void Publish_Throws_When_Uid_Is_Set()
+        {
+            var details = new TaxonomyPublishDetails { Locales = new System.Collections.Generic.List<string> { "en-us" } };
+            Assert.ThrowsException<InvalidOperationException>(() => _stack.Taxonomy(_fixture.Create<string>()).Publish(details));
+            Assert.ThrowsExceptionAsync<InvalidOperationException>(() => _stack.Taxonomy(_fixture.Create<string>()).PublishAsync(details));
+        }
+
+        [TestMethod]
+        public void Unpublish_Throws_When_Uid_Is_Set()
+        {
+            var details = new TaxonomyPublishDetails { Locales = new System.Collections.Generic.List<string> { "en-us" } };
+            Assert.ThrowsException<InvalidOperationException>(() => _stack.Taxonomy(_fixture.Create<string>()).Unpublish(details));
+            Assert.ThrowsExceptionAsync<InvalidOperationException>(() => _stack.Taxonomy(_fixture.Create<string>()).UnpublishAsync(details));
+        }
+
+        [TestMethod]
+        public void Unlocalize_Throws_When_Uid_Is_Empty()
+        {
+            Assert.ThrowsException<ArgumentException>(() => _stack.Taxonomy().Unlocalize("hi-in"));
+            Assert.ThrowsExceptionAsync<ArgumentException>(() => _stack.Taxonomy().UnlocalizeAsync("hi-in"));
+        }
+
+        [TestMethod]
+        public void Should_Publish_Taxonomy()
+        {
+            var details = new TaxonomyPublishDetails
+            {
+                Locales = new System.Collections.Generic.List<string> { "en-us" },
+                Environments = new System.Collections.Generic.List<string> { "production" },
+                Items = new System.Collections.Generic.List<TaxonomyPublishItem> { new TaxonomyPublishItem { Uid = "tax_uid" } }
+            };
+            ContentstackResponse response = _stack.Taxonomy().Publish(details);
+
+            Assert.AreEqual(_contentstackResponse.OpenResponse(), response.OpenResponse());
+            Assert.AreEqual(_contentstackResponse.OpenJsonObjectResponse().ToString(), response.OpenJsonObjectResponse().ToString());
+        }
+
+        [TestMethod]
+        public async System.Threading.Tasks.Task Should_Publish_Taxonomy_Async()
+        {
+            var details = new TaxonomyPublishDetails
+            {
+                Locales = new System.Collections.Generic.List<string> { "en-us" },
+                Environments = new System.Collections.Generic.List<string> { "production" },
+                Items = new System.Collections.Generic.List<TaxonomyPublishItem> { new TaxonomyPublishItem { Uid = "tax_uid" } }
+            };
+            ContentstackResponse response = await _stack.Taxonomy().PublishAsync(details);
+
+            Assert.AreEqual(_contentstackResponse.OpenResponse(), response.OpenResponse());
+            Assert.AreEqual(_contentstackResponse.OpenJsonObjectResponse().ToString(), response.OpenJsonObjectResponse().ToString());
+        }
+
+        [TestMethod]
+        public void Should_Unpublish_Taxonomy()
+        {
+            var details = new TaxonomyPublishDetails
+            {
+                Locales = new System.Collections.Generic.List<string> { "en-us" },
+                Environments = new System.Collections.Generic.List<string> { "production" },
+                Items = new System.Collections.Generic.List<TaxonomyPublishItem> { new TaxonomyPublishItem { Uid = "tax_uid" } }
+            };
+            ContentstackResponse response = _stack.Taxonomy().Unpublish(details);
+
+            Assert.AreEqual(_contentstackResponse.OpenResponse(), response.OpenResponse());
+            Assert.AreEqual(_contentstackResponse.OpenJsonObjectResponse().ToString(), response.OpenJsonObjectResponse().ToString());
+        }
+
+        [TestMethod]
+        public async System.Threading.Tasks.Task Should_Unpublish_Taxonomy_Async()
+        {
+            var details = new TaxonomyPublishDetails
+            {
+                Locales = new System.Collections.Generic.List<string> { "en-us" },
+                Environments = new System.Collections.Generic.List<string> { "production" },
+                Items = new System.Collections.Generic.List<TaxonomyPublishItem> { new TaxonomyPublishItem { Uid = "tax_uid" } }
+            };
+            ContentstackResponse response = await _stack.Taxonomy().UnpublishAsync(details);
+
+            Assert.AreEqual(_contentstackResponse.OpenResponse(), response.OpenResponse());
+            Assert.AreEqual(_contentstackResponse.OpenJsonObjectResponse().ToString(), response.OpenJsonObjectResponse().ToString());
+        }
+
+        [TestMethod]
+        public void Should_Unlocalize_Taxonomy()
+        {
+            string uid = _fixture.Create<string>();
+            ContentstackResponse response = _stack.Taxonomy(uid).Unlocalize("hi-in");
+
+            Assert.AreEqual(_contentstackResponse.OpenResponse(), response.OpenResponse());
+            Assert.AreEqual(_contentstackResponse.OpenJsonObjectResponse().ToString(), response.OpenJsonObjectResponse().ToString());
+        }
+
+        [TestMethod]
+        public async System.Threading.Tasks.Task Should_Unlocalize_Taxonomy_Async()
+        {
+            string uid = _fixture.Create<string>();
+            ContentstackResponse response = await _stack.Taxonomy(uid).UnlocalizeAsync("hi-in");
+
+            Assert.AreEqual(_contentstackResponse.OpenResponse(), response.OpenResponse());
+            Assert.AreEqual(_contentstackResponse.OpenJsonObjectResponse().ToString(), response.OpenJsonObjectResponse().ToString());
+        }
     }
 }

--- a/Contentstack.Management.Core.Unit.Tests/Models/TermTest.cs
+++ b/Contentstack.Management.Core.Unit.Tests/Models/TermTest.cs
@@ -174,5 +174,57 @@ namespace Contentstack.Management.Core.Unit.Tests.Models
             Assert.ThrowsException<ArgumentException>(() => _stack.Taxonomy(taxonomyUid).Terms().Localize(_fixture.Create<TermModel>()));
             Assert.ThrowsExceptionAsync<ArgumentException>(() => _stack.Taxonomy(taxonomyUid).Terms().LocalizeAsync(_fixture.Create<TermModel>()));
         }
+
+        [TestMethod]
+        public void Unlocalize_Throws_When_Term_Uid_Is_Empty()
+        {
+            string taxonomyUid = _fixture.Create<string>();
+            Assert.ThrowsException<ArgumentException>(() => _stack.Taxonomy(taxonomyUid).Terms().Unlocalize("hi-in"));
+            Assert.ThrowsExceptionAsync<ArgumentException>(() => _stack.Taxonomy(taxonomyUid).Terms().UnlocalizeAsync("hi-in"));
+        }
+
+        [TestMethod]
+        public void Should_Unlocalize_Term()
+        {
+            string taxonomyUid = _fixture.Create<string>();
+            string termUid = _fixture.Create<string>();
+            ContentstackResponse response = _stack.Taxonomy(taxonomyUid).Terms(termUid).Unlocalize("hi-in");
+
+            Assert.AreEqual(_contentstackResponse.OpenResponse(), response.OpenResponse());
+            Assert.AreEqual(_contentstackResponse.OpenJsonObjectResponse().ToString(), response.OpenJsonObjectResponse().ToString());
+        }
+
+        [TestMethod]
+        public async System.Threading.Tasks.Task Should_Unlocalize_Term_Async()
+        {
+            string taxonomyUid = _fixture.Create<string>();
+            string termUid = _fixture.Create<string>();
+            ContentstackResponse response = await _stack.Taxonomy(taxonomyUid).Terms(termUid).UnlocalizeAsync("hi-in");
+
+            Assert.AreEqual(_contentstackResponse.OpenResponse(), response.OpenResponse());
+            Assert.AreEqual(_contentstackResponse.OpenJsonObjectResponse().ToString(), response.OpenJsonObjectResponse().ToString());
+        }
+
+        [TestMethod]
+        public void Should_Localize_Term()
+        {
+            string taxonomyUid = _fixture.Create<string>();
+            string termUid = _fixture.Create<string>();
+            ContentstackResponse response = _stack.Taxonomy(taxonomyUid).Terms(termUid).Localize(_fixture.Create<TermModel>());
+
+            Assert.AreEqual(_contentstackResponse.OpenResponse(), response.OpenResponse());
+            Assert.AreEqual(_contentstackResponse.OpenJsonObjectResponse().ToString(), response.OpenJsonObjectResponse().ToString());
+        }
+
+        [TestMethod]
+        public async System.Threading.Tasks.Task Should_Localize_Term_Async()
+        {
+            string taxonomyUid = _fixture.Create<string>();
+            string termUid = _fixture.Create<string>();
+            ContentstackResponse response = await _stack.Taxonomy(taxonomyUid).Terms(termUid).LocalizeAsync(_fixture.Create<TermModel>());
+
+            Assert.AreEqual(_contentstackResponse.OpenResponse(), response.OpenResponse());
+            Assert.AreEqual(_contentstackResponse.OpenJsonObjectResponse().ToString(), response.OpenJsonObjectResponse().ToString());
+        }
     }
 }

--- a/Contentstack.Management.Core/Models/Taxonomy.cs
+++ b/Contentstack.Management.Core/Models/Taxonomy.cs
@@ -161,6 +161,76 @@ namespace Contentstack.Management.Core.Models
         }
 
         /// <summary>
+        /// Publish one or more taxonomies. POST /taxonomies/publish (collection-level, no uid required).
+        /// </summary>
+        public ContentstackResponse Publish(TaxonomyPublishDetails details, ParameterCollection? collection = null)
+        {
+            stack.ThrowIfNotLoggedIn();
+            ThrowIfUidNotEmpty();
+            var service = new TaxonomyPublishService(stack, details, "/taxonomies/publish", collection);
+            return stack.client.InvokeSync(service);
+        }
+
+        /// <summary>
+        /// Publish one or more taxonomies asynchronously.
+        /// </summary>
+        public Task<ContentstackResponse> PublishAsync(TaxonomyPublishDetails details, ParameterCollection? collection = null)
+        {
+            stack.ThrowIfNotLoggedIn();
+            ThrowIfUidNotEmpty();
+            var service = new TaxonomyPublishService(stack, details, "/taxonomies/publish", collection);
+            return stack.client.InvokeAsync<TaxonomyPublishService, ContentstackResponse>(service);
+        }
+
+        /// <summary>
+        /// Unpublish one or more taxonomies. POST /taxonomies/unpublish (collection-level, no uid required).
+        /// </summary>
+        public ContentstackResponse Unpublish(TaxonomyPublishDetails details, ParameterCollection? collection = null)
+        {
+            stack.ThrowIfNotLoggedIn();
+            ThrowIfUidNotEmpty();
+            var service = new TaxonomyPublishService(stack, details, "/taxonomies/unpublish", collection);
+            return stack.client.InvokeSync(service);
+        }
+
+        /// <summary>
+        /// Unpublish one or more taxonomies asynchronously.
+        /// </summary>
+        public Task<ContentstackResponse> UnpublishAsync(TaxonomyPublishDetails details, ParameterCollection? collection = null)
+        {
+            stack.ThrowIfNotLoggedIn();
+            ThrowIfUidNotEmpty();
+            var service = new TaxonomyPublishService(stack, details, "/taxonomies/unpublish", collection);
+            return stack.client.InvokeAsync<TaxonomyPublishService, ContentstackResponse>(service);
+        }
+
+        /// <summary>
+        /// Unlocalize a taxonomy from the given locale. DELETE /taxonomies/{uid}?locale=...
+        /// </summary>
+        public ContentstackResponse Unlocalize(string locale, ParameterCollection? collection = null)
+        {
+            stack.ThrowIfNotLoggedIn();
+            ThrowIfUidEmpty();
+            var coll = collection ?? new ParameterCollection();
+            coll.Add("locale", locale);
+            var service = new FetchDeleteService(stack, resourcePath, "DELETE", coll);
+            return stack.client.InvokeSync(service);
+        }
+
+        /// <summary>
+        /// Unlocalize a taxonomy asynchronously.
+        /// </summary>
+        public Task<ContentstackResponse> UnlocalizeAsync(string locale, ParameterCollection? collection = null)
+        {
+            stack.ThrowIfNotLoggedIn();
+            ThrowIfUidEmpty();
+            var coll = collection ?? new ParameterCollection();
+            coll.Add("locale", locale);
+            var service = new FetchDeleteService(stack, resourcePath, "DELETE", coll);
+            return stack.client.InvokeAsync<FetchDeleteService, ContentstackResponse>(service);
+        }
+
+        /// <summary>
         /// Import taxonomy. POST /taxonomies/import with multipart form (taxonomy file).
         /// </summary>
         public ContentstackResponse Import(TaxonomyImportModel model, ParameterCollection? collection = null)

--- a/Contentstack.Management.Core/Models/TaxonomyPublishDetails.cs
+++ b/Contentstack.Management.Core/Models/TaxonomyPublishDetails.cs
@@ -1,0 +1,32 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace Contentstack.Management.Core.Models
+{
+    /// <summary>
+    /// Details for publishing or unpublishing one or more taxonomies.
+    /// </summary>
+    public class TaxonomyPublishDetails
+    {
+        [JsonPropertyName("locales")]
+        public List<string>? Locales { get; set; }
+
+        [JsonPropertyName("environments")]
+        public List<string>? Environments { get; set; }
+
+        [JsonPropertyName("scheduled_at")]
+        public string? ScheduledAt { get; set; }
+
+        [JsonPropertyName("items")]
+        public List<TaxonomyPublishItem>? Items { get; set; }
+    }
+
+    /// <summary>
+    /// Identifies a taxonomy to publish or unpublish by UID.
+    /// </summary>
+    public class TaxonomyPublishItem
+    {
+        [JsonPropertyName("uid")]
+        public string Uid { get; set; } = null!;
+    }
+}

--- a/Contentstack.Management.Core/Models/Term.cs
+++ b/Contentstack.Management.Core/Models/Term.cs
@@ -205,6 +205,32 @@ namespace Contentstack.Management.Core.Models
         }
 
         /// <summary>
+        /// Unlocalize a term from the given locale. DELETE /taxonomies/{uid}/terms/{term_uid}?locale=...
+        /// </summary>
+        public ContentstackResponse Unlocalize(string locale, ParameterCollection? collection = null)
+        {
+            stack.ThrowIfNotLoggedIn();
+            ThrowIfUidEmpty();
+            var coll = collection ?? new ParameterCollection();
+            coll.Add("locale", locale);
+            var service = new FetchDeleteService(stack, resourcePath, "DELETE", coll);
+            return stack.client.InvokeSync(service);
+        }
+
+        /// <summary>
+        /// Unlocalize a term asynchronously.
+        /// </summary>
+        public Task<ContentstackResponse> UnlocalizeAsync(string locale, ParameterCollection? collection = null)
+        {
+            stack.ThrowIfNotLoggedIn();
+            ThrowIfUidEmpty();
+            var coll = collection ?? new ParameterCollection();
+            coll.Add("locale", locale);
+            var service = new FetchDeleteService(stack, resourcePath, "DELETE", coll);
+            return stack.client.InvokeAsync<FetchDeleteService, ContentstackResponse>(service);
+        }
+
+        /// <summary>
         /// Search terms across all taxonomies. GET /taxonomies/$all/terms with typeahead query param. Callable only when no specific term UID is set.
         /// </summary>
         /// <param name="typeahead">Search string for typeahead.</param>

--- a/Contentstack.Management.Core/Services/Models/TaxonomyPublishService.cs
+++ b/Contentstack.Management.Core/Services/Models/TaxonomyPublishService.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Text.Json;
+using Contentstack.Management.Core.Models;
+using Contentstack.Management.Core.Queryable;
+using Contentstack.Management.Core.Utils;
+
+namespace Contentstack.Management.Core.Services.Models
+{
+    internal class TaxonomyPublishService : ContentstackService
+    {
+        private readonly TaxonomyPublishDetails _details;
+
+        internal TaxonomyPublishService(Core.Models.Stack stack, TaxonomyPublishDetails details, string resourcePath, ParameterCollection? collection = null, JsonSerializerOptions? stjOptions = null)
+            : base(stjOptions ?? stack?.client?.SerializerOptions ?? new JsonSerializerOptions(), stack: stack, collection: collection)
+        {
+            if (stack!.APIKey == null)
+                throw new ArgumentNullException("stack", CSConstants.MissingAPIKey);
+            if (details == null)
+                throw new ArgumentNullException("details", CSConstants.PublishDetailsRequired);
+            if (resourcePath == null)
+                throw new ArgumentNullException("resourcePath", CSConstants.ResourcePathRequired);
+
+            this.ResourcePath = resourcePath;
+            this.HttpMethod = "POST";
+            _details = details;
+        }
+
+        public override void ContentBody()
+        {
+            string jsonString = JsonSerializer.Serialize(_details, SerializerOptions);
+            this.ByteContent = System.Text.Encoding.UTF8.GetBytes(jsonString);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `Taxonomy.Publish()` / `Unpublish()` — `POST /taxonomies/publish|unpublish` (collection-level, no uid)
- Adds `Taxonomy.Unlocalize()` — `DELETE /taxonomies/{uid}?locale=...` (Localize already existed)
- Adds `Term.Unlocalize()` — `DELETE /taxonomies/{uid}/terms/{uid}?locale=...` (Localize already existed)
- New `TaxonomyPublishDetails` model with `Items` list; `TaxonomyPublishService` serializes body directly without field wrapper

## Reference
- Java implementation: `feat/DX-9676-taxonomy-publish` (PR #262) — translated to .NET idioms
- TRD: https://contentstack.atlassian.net/wiki/spaces/CD/pages/3573580300/

## Test plan
- [x] Unit tests: 46 pass (`TaxonomyTest` + `TermTest` in `Contentstack.Management.Core.Unit.Tests`)
- [ ] Integration tests in `Contentstack017_TaxonomyTest.cs` — require live credentials to run

🤖 Generated with [Claude Code](https://claude.com/claude-code)